### PR TITLE
Add PHP Unit 9 to requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
         "php": ">=7.2.0",
         "psr/container": "^2.0",
         "ext-json": "*",
-        "phpunit/phpunit": "8.*"
+        "phpunit/phpunit": "8.*||9.*"
     }
 }


### PR DESCRIPTION
## Overview
Laravel 8 is locked to phpunit 9.3 so refuses to install package. Updating the requirements this way so this change is backwards-compatible.

## Changes
- Updated `composer.json` to allow version 8 or 9 of phpunit

## Testing
- I installed phpunit 9.3 locally and ran tests and all passed as they did when using phpunit 8

## Further considerations
- Current versions of phpunit 9 have not introduced breaking changes, but I believe the owners haven't ruled this out in the future, so may potentially want to cap the version 9 requirement to last known minor version