### PR TITLE
Extra Mutators and tests

### DIFF
--- a/src/CastType/Date.php
+++ b/src/CastType/Date.php
@@ -32,7 +32,7 @@ class Date implements CastTypeInterface
     public function cast($originalValue)
     {
         if (!$this->model->getFormat()) {
-            throw new \InvalidArgumentException(__('The format must be provided!'));
+            throw new \InvalidArgumentException('The format must be provided!');
         }
         $date = new \DateTime($originalValue);
         return $date->format($this->model->getFormat());

--- a/src/Mutator/Add.php
+++ b/src/Mutator/Add.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Data Mapper (https://github.com/mozahran/data-mapper)
+ * Copyright 2021, Mohamed Zahran. (https://www.linkedin.com/in/mo-zahran/)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mohamed Zahran (https://www.linkedin.com/in/mo-zahran/)
+ * @link          https://github.com/mozahran/data-mapper
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Zahran\Mapper\Mutator;
+
+use Zahran\Mapper\Contract\Mutator as MutatorInterface;
+use Zahran\Mapper\Model\Mutator;
+
+class Add implements MutatorInterface
+{
+    /**
+     * @var Mutator
+     */
+    protected $model;
+
+    public function setModel(Mutator $model): MutatorInterface
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function apply($originalValue, array $arguments = [])
+    {
+        $newValue = $originalValue;
+        for($i=0; $i < count($arguments); $i++) {
+            $newValue += $arguments[$i];
+        }
+        return $newValue;
+    }
+}

--- a/src/Mutator/BaseConvert.php
+++ b/src/Mutator/BaseConvert.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Data Mapper (https://github.com/mozahran/data-mapper)
+ * Copyright 2021, Mohamed Zahran. (https://www.linkedin.com/in/mo-zahran/)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mohamed Zahran (https://www.linkedin.com/in/mo-zahran/)
+ * @link          https://github.com/mozahran/data-mapper
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Zahran\Mapper\Mutator;
+
+use Zahran\Mapper\Contract\Mutator as MutatorInterface;
+use Zahran\Mapper\Model\Mutator;
+
+class BaseConvert implements MutatorInterface
+{
+    /**
+     * @var Mutator
+     */
+    protected $model;
+
+    protected $defaultToBase = 10;
+
+    public function setModel(Mutator $model): MutatorInterface
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function apply($originalValue, array $arguments = [])
+    {
+        $fromBase = (int) $arguments[0];
+        $toBase = ( isset($arguments[1]) && (int) $arguments[1] > 0 ) ? (int) $arguments[1]:$this->defaultToBase;
+        return base_convert($originalValue,$fromBase,$toBase);
+    }
+}

--- a/src/Mutator/Divide.php
+++ b/src/Mutator/Divide.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Data Mapper (https://github.com/mozahran/data-mapper)
+ * Copyright 2021, Mohamed Zahran. (https://www.linkedin.com/in/mo-zahran/)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mohamed Zahran (https://www.linkedin.com/in/mo-zahran/)
+ * @link          https://github.com/mozahran/data-mapper
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Zahran\Mapper\Mutator;
+
+use Zahran\Mapper\Contract\Mutator as MutatorInterface;
+use Zahran\Mapper\Model\Mutator;
+
+class Divide implements MutatorInterface
+{
+    /**
+     * @var Mutator
+     */
+    protected $model;
+
+    public function setModel(Mutator $model): MutatorInterface
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function apply($originalValue, array $arguments = [])
+    {
+        $newValue = $originalValue;
+        for($i=0; $i < count($arguments); $i++) {
+            $newValue /= $arguments[$i];
+        }
+        return $newValue;
+    }
+}

--- a/src/Mutator/Exponential.php
+++ b/src/Mutator/Exponential.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Data Mapper (https://github.com/mozahran/data-mapper)
+ * Copyright 2021, Mohamed Zahran. (https://www.linkedin.com/in/mo-zahran/)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mohamed Zahran (https://www.linkedin.com/in/mo-zahran/)
+ * @link          https://github.com/mozahran/data-mapper
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Zahran\Mapper\Mutator;
+
+use Zahran\Mapper\Contract\Mutator as MutatorInterface;
+use Zahran\Mapper\Model\Mutator;
+
+class Exponential implements MutatorInterface
+{
+    /**
+     * @var Mutator
+     */
+    protected $model;
+
+    public function setModel(Mutator $model): MutatorInterface
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function apply($originalValue, array $arguments = [])
+    {
+        $newValue = $originalValue;
+        for($i=0; $i < count($arguments); $i++) {
+            $newValue **= $arguments[$i];
+        }
+        return $newValue;
+    }
+}

--- a/src/Mutator/Modulo.php
+++ b/src/Mutator/Modulo.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Data Mapper (https://github.com/mozahran/data-mapper)
+ * Copyright 2021, Mohamed Zahran. (https://www.linkedin.com/in/mo-zahran/)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mohamed Zahran (https://www.linkedin.com/in/mo-zahran/)
+ * @link          https://github.com/mozahran/data-mapper
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Zahran\Mapper\Mutator;
+
+use Zahran\Mapper\Contract\Mutator as MutatorInterface;
+use Zahran\Mapper\Model\Mutator;
+
+class Modulo implements MutatorInterface
+{
+    /**
+     * @var Mutator
+     */
+    protected $model;
+
+    public function setModel(Mutator $model): MutatorInterface
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function apply($originalValue, array $arguments = [])
+    {
+        return fmod(floatval($originalValue),floatval($arguments[0]));
+    }
+}

--- a/src/Mutator/Subtract.php
+++ b/src/Mutator/Subtract.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Data Mapper (https://github.com/mozahran/data-mapper)
+ * Copyright 2021, Mohamed Zahran. (https://www.linkedin.com/in/mo-zahran/)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Mohamed Zahran (https://www.linkedin.com/in/mo-zahran/)
+ * @link          https://github.com/mozahran/data-mapper
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Zahran\Mapper\Mutator;
+
+use Zahran\Mapper\Contract\Mutator as MutatorInterface;
+use Zahran\Mapper\Model\Mutator;
+
+class Subtract implements MutatorInterface
+{
+    /**
+     * @var Mutator
+     */
+    protected $model;
+
+    public function setModel(Mutator $model): MutatorInterface
+    {
+        $this->model = $model;
+        return $this;
+    }
+
+    public function apply($originalValue, array $arguments = [])
+    {
+        $newValue = $originalValue;
+        for($i=0; $i < count($arguments); $i++) {
+            $newValue -= $arguments[$i];
+        }
+        return $newValue;
+    }
+}

--- a/tests/CastTypes/BooleanCastTypeTest.php
+++ b/tests/CastTypes/BooleanCastTypeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace CastTypes;
+
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\CastType\Boolean;
+use Zahran\Mapper\Model\CastType;
+
+class BooleanCastTypeTest extends TestCase
+{
+    protected $castType;
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->castType = new Boolean;
+        $this->castType->setModel(new CastType([
+            CastType::ATTRIBUTE_TYPE => "boolean"
+        ]));
+    }
+
+    /** @test */
+    function it_can_cast_numerals_as_a_boolean()
+    {
+        $originalNumeral = 1;
+        $castTo = $this->castType->cast($originalNumeral);
+        $this->assertSame(boolval($originalNumeral),$castTo,"Converts numerals to booleans");
+        $this->assertNotSame($originalNumeral,$castTo,"Original value casting should have changed");
+        $this->assertTrue( $castTo ,"Original value should now equate to true");
+    } //EOF it_can_cast_numerals_as_a_boolean
+
+    /** @test */
+    function it_can_cast_strings_as_a_boolean()
+    {
+        $originalNumeral = "1";
+        $castTo = $this->castType->cast($originalNumeral);
+        $this->assertSame(boolval($originalNumeral),$castTo,"Converts strings to booleans");
+        $this->assertNotSame($originalNumeral,$castTo,"Original value casting should have changed");
+        $this->assertTrue( $castTo ,"Original value should now equate to true");
+    } //EOF it_can_cast_strings_as_a_boolean
+
+    /** @test */
+    function it_keeps_booleans_as_booleans()
+    {
+        $originalNumeral = true;
+        $castTo = $this->castType->cast($originalNumeral);
+        $this->assertSame($originalNumeral,$castTo,"Original value casting should match the output");
+        $this->assertTrue( $castTo ,"Original value should still equate to true");
+    } //EOF it_keeps_booleans_as_booleans
+
+}

--- a/tests/CastTypes/DateCastTypeTest.php
+++ b/tests/CastTypes/DateCastTypeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace CastTypes;
+
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\CastType\Date;
+use Zahran\Mapper\Model\CastType;
+
+class DateCastTypeTest extends TestCase
+{
+    const ATTRIBUTE_TYPE = "date";
+    protected $castType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->castType = new Date;
+
+    }
+
+    /** @test */
+    function it_can_format_date_to_string_supplied()
+    {
+        $originalValue = "2021-03-21 09:34:15";
+        $format = "d/m/Y H:i";
+
+        $this->castType->setModel(new CastType([
+            CastType::ATTRIBUTE_TYPE => self::ATTRIBUTE_TYPE,
+            CastType::ATTRIBUTE_FORMAT => $format,
+        ]));
+
+        $reformattedDate = $this->castType->cast($originalValue);
+
+        $this->assertSame( ( new \DateTime($originalValue))->format($format), $reformattedDate, "Original value should now be in new date format");
+        $this->assertNotSame($originalValue,$reformattedDate,"Original value should have changed");
+
+    } //EOF it_can_format_date_to_string_supplied
+
+    /** @test */
+    function it_can_format_date_to_constant_supplied()
+    {
+        $originalValue = "2021-03-21 09:34:15";
+        $format = \DateTimeInterface::ISO8601;
+
+        $this->castType->setModel(new CastType([
+            CastType::ATTRIBUTE_TYPE => self::ATTRIBUTE_TYPE,
+            CastType::ATTRIBUTE_FORMAT => $format,
+        ]));
+
+        $reformattedDate = $this->castType->cast($originalValue);
+
+        $this->assertSame( ( new \DateTime($originalValue))->format($format), $reformattedDate, "Original value should now be in new date format");
+        $this->assertNotSame($originalValue,$reformattedDate,"Original value should have changed");
+
+    } //EOF it_can_format_date_to_constant_supplied
+
+    /** @test */
+    function it_throws_exception_if_format_missing()
+    {
+        $originalValue = "2021-03-21 09:34:15";
+
+        $this->expectExceptionObject(new \InvalidArgumentException('The format must be provided!'));
+
+        $this->castType->setModel(new CastType([
+            CastType::ATTRIBUTE_TYPE => self::ATTRIBUTE_TYPE,
+        ]));
+
+        $this->castType->cast($originalValue);
+
+    } //EOF it_throws_exception_if_format_missing
+}

--- a/tests/Mutators/AdditionFunctionTest.php
+++ b/tests/Mutators/AdditionFunctionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace Mutators;
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\Model\Mutator;
+use Zahran\Mapper\Mutator\Add;
+
+class AdditionFunctionTest extends TestCase
+{
+    const MUTATOR_NAME = "add";
+    protected $mutatorType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->mutatorType = new Add;
+        $this->mutatorType->setModel(new Mutator([
+            Mutator::ATTRIBUTE_NAME => self::MUTATOR_NAME,
+            Mutator::ATTRIBUTE_ARGUMENTS => [],
+        ]));
+    }
+
+    /** @test */
+    function it_can_add_to_original_value()
+    {
+        $originalValue = 12;
+        $add = 5;
+
+        $addedValue = $this->mutatorType->apply($originalValue,[$add]);
+        $this->assertSame( ($originalValue + $add), $addedValue, "Original value should be correctly added together");
+        $this->assertNotSame( $originalValue, $addedValue, "Original value should have mutated");
+    } //EOF it_can_add_to_original_value
+
+    /** @test */
+
+    function it_can_add_original_value_multiple_times()
+    {
+        $originalValue = 12;
+        $add = 5;
+        $thenAnd = 12;
+        $finallyAdd = 43;
+
+        $addedValue = $this->mutatorType->apply($originalValue,[$add,$thenAnd,$finallyAdd]);
+        $this->assertNotSame( ($originalValue + $add), $addedValue, "Value not just adding the first argument");
+        $this->assertSame( ( $originalValue + $add + $thenAnd + $finallyAdd), $addedValue, "Original value should add each argument supplied");
+    } //EOF it_can_add_original_value_multiple_times
+}

--- a/tests/Mutators/BaseConvertFunctionTest.php
+++ b/tests/Mutators/BaseConvertFunctionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Mutators;
+
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\Model\Mutator;
+use Zahran\Mapper\Mutator\BaseConvert;
+
+class BaseConvertFunctionTest extends TestCase
+{
+    const MUTATOR_NAME = "base-convert";
+    protected $mutatorType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->mutatorType = new BaseConvert;
+        $this->mutatorType->setModel(new Mutator([
+            Mutator::ATTRIBUTE_NAME => self::MUTATOR_NAME,
+            Mutator::ATTRIBUTE_ARGUMENTS => [],
+        ]));
+    }
+
+    /** @test */
+    function it_converts_a_number_to_different_base()
+    {
+        $originalValue = 'a37334'; // hexadecimal
+        $fromBase = 16;
+        $toBase = 2;
+
+        $rebasedValue = $this->mutatorType->apply($originalValue,[$fromBase, $toBase]);
+        $this->assertSame( base_convert($originalValue,$fromBase,$toBase), $rebasedValue,"It converts base" );
+        $this->assertNotSame( $originalValue, $rebasedValue,"The original value should have changed base" );
+    } //EOF it_converts_a_number_to_different_base
+
+    /** @test */
+    function it_defaults_to_base_ten_if_missing_second_argument()
+    {
+        $originalValue = 'a37334'; // hexadecimal
+        $fromBase = 16;
+        $rebasedValue = $this->mutatorType->apply($originalValue,[$fromBase]);
+        $this->assertSame( base_convert($originalValue,$fromBase,10), $rebasedValue,"It defaults to base into base 10" );
+
+    } //EOF it_converts_a_number_to_different_base
+}

--- a/tests/Mutators/DivideFunctionTest.php
+++ b/tests/Mutators/DivideFunctionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Mutators;
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\Model\Mutator;
+use Zahran\Mapper\Mutator\Divide;
+
+class DivideFunctionTest extends TestCase
+{
+    const MUTATOR_NAME = "divide";
+    protected $mutatorType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->mutatorType = new Divide;
+        $this->mutatorType->setModel(new Mutator([
+            Mutator::ATTRIBUTE_NAME => self::MUTATOR_NAME,
+            Mutator::ATTRIBUTE_ARGUMENTS => [],
+        ]));
+    }
+
+    /** @test */
+    function it_can_divide_original_value()
+    {
+        $originalValue = 12;
+        $divideBy = 5;
+
+        $dividedValue = $this->mutatorType->apply($originalValue,[$divideBy]);
+        $this->assertSame( ($originalValue / $divideBy), $dividedValue, "Original value should be correctly divided");
+        $this->assertNotSame( $originalValue, $dividedValue, "Original value should have mutated");
+    } //EOF it_can_divide_original_value
+
+    /** @test */
+    function it_can_divide_original_value_multiple_times()
+    {
+        $originalValue = 12;
+        $divideBy = 5;
+        $thenDivideBy = 2;
+
+        $dividedValue = $this->mutatorType->apply($originalValue,[$divideBy,$thenDivideBy]);
+        $this->assertNotSame( ($originalValue / $divideBy), $dividedValue, "Value not just divided by first argument");
+        $this->assertSame( ( $originalValue / $divideBy / $thenDivideBy), $dividedValue, "Original value should be divided by each argument supplied");
+    } //EOF it_can_divide_original_value_multiple_times
+}

--- a/tests/Mutators/ExponentialFunctionTest.php
+++ b/tests/Mutators/ExponentialFunctionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace Mutators;
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\Model\Mutator;
+use Zahran\Mapper\Mutator\Exponential;
+
+class ExponentialFunctionTest extends TestCase
+{
+    const MUTATOR_NAME = "exponential";
+    protected $mutatorType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->mutatorType = new Exponential;
+        $this->mutatorType->setModel(new Mutator([
+            Mutator::ATTRIBUTE_NAME => self::MUTATOR_NAME,
+            Mutator::ATTRIBUTE_ARGUMENTS => [],
+        ]));
+    }
+
+    /** @test */
+    function it_can_raise_the_power_of_original_value()
+    {
+        $originalValue = 12;
+        $raisedToPowerOf = 3;
+
+        $mutatedValue = $this->mutatorType->apply($originalValue,[$raisedToPowerOf]);
+        $this->assertSame( ($originalValue ** $raisedToPowerOf), $mutatedValue, "Original value should be correctly raised to the power");
+        $this->assertNotSame( $originalValue, $mutatedValue, "Original value should have mutated");
+    } //EOF it_can_raise_the_power_of_original_value
+
+    /** @test */
+
+    function it_can_raise_the_power_of_the_original_value_multiple_times()
+    {
+        $originalValue = 34;
+        $raiseToThePowerOf = 2;
+        $thenRaiseTo = 2;
+
+        $mutatedValue = $this->mutatorType->apply($originalValue,[$raiseToThePowerOf,$thenRaiseTo]);
+        $this->assertNotSame( ($originalValue ** $raiseToThePowerOf), $mutatedValue, "Value not just raising the power of the first argument");
+        $this->assertSame( ( $originalValue ** $raiseToThePowerOf ** $thenRaiseTo), $mutatedValue, "Original value should raise to the power of each argument supplied");
+    } //EOF it_can_raise_the_power_of_the_original_value_multiple_times
+}

--- a/tests/Mutators/ModuloFunctionTest.php
+++ b/tests/Mutators/ModuloFunctionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace Mutators;
+
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\Model\Mutator;
+use Zahran\Mapper\Mutator\BaseConvert;
+use Zahran\Mapper\Mutator\Modulo;
+
+class ModuloFunctionTest extends TestCase
+{
+    const MUTATOR_NAME = "modulo";
+    protected $mutatorType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->mutatorType = new Modulo;
+        $this->mutatorType->setModel(new Mutator([
+            Mutator::ATTRIBUTE_NAME => self::MUTATOR_NAME,
+            Mutator::ATTRIBUTE_ARGUMENTS => [],
+        ]));
+    }
+
+    /** @test */
+    function it_returns_the_modulo_of_both_numbers()
+    {
+        $firstNumber = 5.7;
+        $secondNumber = 1.3;
+
+        $modulo = $this->mutatorType->apply($firstNumber,[$secondNumber]);
+        $this->assertSame(fmod($firstNumber,$secondNumber), $modulo,"It returns the remainder of the original value divided by the second" );
+        $this->assertNotSame( $firstNumber, $modulo,"The original value should have changed" );
+    } //EOF it_returns_the_modulo_of_both_numbers
+
+    /** @test */
+    function it_returns_the_modulo_if_numeric_strings()
+    {
+        $firstNumber = "5.7";
+        $secondNumber = "1.3";
+
+        $modulo = $this->mutatorType->apply($firstNumber,[$secondNumber]);
+        $this->assertSame(fmod(floatval($firstNumber),floatval($secondNumber)), $modulo,"It converts string arguments to floating point numbers" );
+    } //EOF it_returns_the_modulo_if_numeric_strings
+
+}

--- a/tests/Mutators/ModuloFunctionTest.php
+++ b/tests/Mutators/ModuloFunctionTest.php
@@ -6,7 +6,6 @@ namespace Mutators;
 
 use PHPUnit\Framework\TestCase;
 use Zahran\Mapper\Model\Mutator;
-use Zahran\Mapper\Mutator\BaseConvert;
 use Zahran\Mapper\Mutator\Modulo;
 
 class ModuloFunctionTest extends TestCase

--- a/tests/Mutators/MultiplyFunctionTest.php
+++ b/tests/Mutators/MultiplyFunctionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+
+namespace Mutators;
+
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\Model\Mutator;
+use Zahran\Mapper\Mutator\Multiply;
+
+class MultiplyFunctionTest extends TestCase
+{
+    const MUTATOR_NAME = "multiply";
+
+    protected $mutatorType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->mutatorType = new Multiply;
+        $this->mutatorType->setModel(new Mutator([
+            Mutator::ATTRIBUTE_NAME => self::MUTATOR_NAME,
+            Mutator::ATTRIBUTE_ARGUMENTS => [],
+        ]));
+
+    }
+
+    /** @test */
+    function it_multiplies_data_by_first_argument()
+    {
+        $originalValue = 12;
+        $multiplyBy = 5; // could use Faker to make both of these random in the future...
+
+        $multipliedValue = $this->mutatorType->apply($originalValue,[$multiplyBy]);
+        $this->assertSame( ( $originalValue * $multiplyBy ), $multipliedValue,"The mutator applies the multiplication" );
+        $this->assertNotSame( $originalValue, $multipliedValue,"The original value should be changed" );
+
+    } //EOF it_multiplies_data_by_first_argument
+
+    /** @test */
+    function it_does_not_multiply_subsequent_arguments()
+    {
+        $originalValue = 21;
+        $multiplyBy = 7;
+        $doNotMultiplyBy = 8;
+        $norMultiplyBy = 9;
+
+        $multipliedValue = $this->mutatorType->apply($originalValue,[$multiplyBy,$doNotMultiplyBy,$norMultiplyBy]);
+        $this->assertSame(( $originalValue * $multiplyBy ), $multipliedValue,"The mutator multiplies by first argument");
+        $this->assertNotSame(( $originalValue * $doNotMultiplyBy ), $multipliedValue,"The mutator ignores the second argument");
+        $this->assertNotSame(( $originalValue * $norMultiplyBy ), $multipliedValue,"The mutator ignores the third argument");
+
+    } //EOF it_does_not_multiply_subsequent_arguments
+
+    /** @test */
+    function it_multiplies_decimals()
+    {
+        $originalValue = 12.345;
+        $multiplyBy = 5.67; // could use Faker to make both of these random in the future...
+
+        $multipliedValue = $this->mutatorType->apply($originalValue,[$multiplyBy]);
+        $this->assertSame( ( $originalValue * $multiplyBy ), $multipliedValue,"The mutator works with decimals and floating point numbers" );
+    } //EOF it_multiplies_decimals
+
+    /** @test */
+    function it_can_multiply_string_arguments()
+    {
+        $originalValue = "24";
+        $multiplyBy = "5"; // could use Faker to make both of these random in the future...
+
+        $multipliedValue = $this->mutatorType->apply($originalValue,[$multiplyBy]);
+        $this->assertSame( ( (int)$originalValue * (int) $multiplyBy ), $multipliedValue,"The mutator casts strings to numbers" );
+    } //EOF it_can_multiply_string_arguments
+}

--- a/tests/Mutators/SubtractFunctionTest.php
+++ b/tests/Mutators/SubtractFunctionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace Mutators;
+
+use PHPUnit\Framework\TestCase;
+use Zahran\Mapper\Model\Mutator;
+use Zahran\Mapper\Mutator\Subtract;
+
+class SubtractFunctionTest extends TestCase
+{
+    const MUTATOR_NAME = "subtract";
+    protected $mutatorType;
+
+    function setUp(): void
+    {
+        parent::setUp();
+        $this->mutatorType = new Subtract;
+        $this->mutatorType->setModel(new Mutator([
+            Mutator::ATTRIBUTE_NAME => self::MUTATOR_NAME,
+            Mutator::ATTRIBUTE_ARGUMENTS => [],
+        ]));
+    }
+
+    /** @test */
+    function it_can_subtract_from_original_value()
+    {
+        $originalValue = 12;
+        $subtract = 5;
+
+        $subtractedValue = $this->mutatorType->apply($originalValue,[$subtract]);
+        $this->assertSame( ($originalValue - $subtract), $subtractedValue, "Original value should be correctly subtracted");
+        $this->assertNotSame( $originalValue, $subtractedValue, "Original value should have mutated");
+    } //EOF it_can_subtract_from_original_value
+
+    /** @test */
+
+    function it_can_subtract_from_original_value_multiple_times()
+    {
+        $originalValue = 12;
+        $subtract = 5;
+        $thenSubtract = 12;
+        $finallySubtract = 43;
+
+        $subtractedValue = $this->mutatorType->apply($originalValue,[$subtract,$thenSubtract,$finallySubtract]);
+        $this->assertNotSame( ($originalValue - $subtract), $subtractedValue, "Value not just subtracting the first argument");
+        $this->assertSame( ( $originalValue - $subtract - $thenSubtract - $finallySubtract), $subtractedValue, "Original value should subtract each argument supplied");
+    } //EOF it_can_subtract_from_original_value_multiple_times
+}


### PR DESCRIPTION
## Overview
I have added in some new mutators (with tests) and begun adding some tests for existing mutators and cast types.

## Added
- Addition mutator (with tests)
- Subtraction mutator (with tests)
- Division mutator (with tests)
- Power of / expontential mutator (with tests)
- Modulo mutator (with tests)
- Base conversion mutator (with tests)
- Multiplication tests
- Boolean cast type test
- Date format cast type test

## Fixes
- When running the date cast tests I never got the InvalidArgumentException because of an unknown class error. Removing the translation function `__()` resolved this for me.

## Testing
- All tests passing on **phpunit 9.3**

## Further considerations
- We may want to use `Faker` or similar in the test suite to generate random values to test with.
- With the `Add` / `Subtract` / `Divide` / `Exponential` mutators **I introduced a behaviour change** with additional arguments, compared with how that works with the `Multiply` mutator. Those new mutators will apply any subsequent arguments provided (rather than just the first). I'll be honest I'm not 100% it will be needed, I was just wondering on a use case where I might want to potentially want to be passing in a constant and then a unique power. If you'd rather this stick to the behaviour of multiply, reject this and I'll correct accordingly.